### PR TITLE
whiteboard.pro: Add builddir to install files

### DIFF
--- a/whiteboard.pro
+++ b/whiteboard.pro
@@ -31,7 +31,7 @@ HEADERS  += mainwindow.h \
     whiteboard.h
 
 target.path = /opt/whiteboard
-target.files = whiteboard
+target.files = $$top_builddir/whiteboard
 extra.path = /opt/whiteboard
 extra.files = resources/whiteboard.sh
 configfile.path = /opt/ApplicationLauncher/applications/xml


### PR DESCRIPTION
Fixes install errors when Srcdir != Builddir

Signed-off-by: Khem Raj <raj.khem@gmail.com>